### PR TITLE
fix mevboost flag key

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SUPPORTED_NETWORKS="gnosis holesky mainnet"
-MEVBOOST_FLAG="--builder-proposals"
+MEVBOOST_FLAG_KEY="--builder-proposals"
 SKIP_MEVBOOST_URL="true"
 CLIENT="lighthouse"
 


### PR DESCRIPTION
`get_mevboost_flag` is supposted to be called with the the mevboost key of each consensus client. In this case, `--builder-proposals`.

