### PR TITLE
Update for electra

### DIFF
--- a/package_variants/holesky/dappnode_package.json
+++ b/package_variants/holesky/dappnode_package.json
@@ -1,4 +1,11 @@
 {
+  "upstream": [
+    {
+      "repo": "sigp/lighthouse",
+      "version": "v7.0.0-beta.0",
+      "arg": "UPSTREAM_VERSION"
+    }
+  ],
   "name": "lighthouse-holesky.dnp.dappnode.eth",
   "version": "0.1.6",
   "links": {

--- a/package_variants/holesky/docker-compose.yml
+++ b/package_variants/holesky/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: beacon-chain
       args:
+        UPSTREAM_VERSION: v7.0.0-beta.0 ## To be removed once Pectra is live. v7.0.0-beta.0 is a holesky-only release
         NETWORK: holesky 
         P2P_PORT: 9604
     ports:
@@ -15,3 +16,4 @@ services:
     build:
       args:
         NETWORK: holesky
+        UPSTREAM_VERSION: v7.0.0-beta.0  ## To be removed once Pectra is live. v7.0.0-beta.0 is a holesky-only release


### PR DESCRIPTION
Changes from this PR should be reverted once Pectra is live. `v7.0.0-beta.0` is a testnet-only release