### PR TITLE
Bump holesky version

### DIFF
--- a/package_variants/holesky/dappnode_package.json
+++ b/package_variants/holesky/dappnode_package.json
@@ -2,12 +2,12 @@
   "upstream": [
     {
       "repo": "sigp/lighthouse",
-      "version": "v7.0.0-beta.0",
+      "version": "v7.0.0-beta.1",
       "arg": "UPSTREAM_VERSION"
     }
   ],
   "name": "lighthouse-holesky.dnp.dappnode.eth",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "links": {
     "ui": "http://brain.web3signer-holesky.dappnode",
     "homepage": "https://github.com/dappnode/DAppNodePackage-lighthouse-generic#readme",

--- a/package_variants/holesky/docker-compose.yml
+++ b/package_variants/holesky/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v7.0.0-beta.0 ## To be removed once Pectra is live. v7.0.0-beta.0 is a holesky-only release
+        UPSTREAM_VERSION: v7.0.0-beta.1 ## To be removed once Pectra is live. v7.0.0-beta.1 is a holesky-only release
         NETWORK: holesky 
         P2P_PORT: 9604
     ports:
@@ -16,4 +16,4 @@ services:
     build:
       args:
         NETWORK: holesky
-        UPSTREAM_VERSION: v7.0.0-beta.0  ## To be removed once Pectra is live. v7.0.0-beta.0 is a holesky-only release
+        UPSTREAM_VERSION: v7.0.0-beta.1  ## To be removed once Pectra is live. v7.0.0-beta.1 is a holesky-only release


### PR DESCRIPTION
Should be an easier way of getting a v7.0.0-beta.1 package, but here we are....