### PR TITLE
stop using beta releases for testnets

### DIFF
--- a/package_variants/gnosis/docker-compose.yml
+++ b/package_variants/gnosis/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "19004:19004/tcp"
       - "19004:19004/udp"
     environment:
-      CORSDOMAIN: "http://lighthouse.dappnode"
+      CORSDOMAIN: "http://lighthouse-gnosis.dappnode"
   validator:
     build:
       args:

--- a/package_variants/holesky/dappnode_package.json
+++ b/package_variants/holesky/dappnode_package.json
@@ -1,11 +1,4 @@
 {
-  "upstream": [
-    {
-      "repo": "sigp/lighthouse",
-      "version": "v7.0.0",
-      "arg": "UPSTREAM_VERSION"
-    }
-  ],
   "name": "lighthouse-holesky.dnp.dappnode.eth",
   "version": "0.1.7",
   "links": {

--- a/package_variants/hoodi/dappnode_package.json
+++ b/package_variants/hoodi/dappnode_package.json
@@ -1,11 +1,4 @@
 {
-  "upstream": [
-    {
-      "repo": "sigp/lighthouse",
-      "version": "v7.0.0",
-      "arg": "UPSTREAM_VERSION"
-    }
-  ],
   "name": "lighthouse-hoodi.dnp.dappnode.eth",
   "version": "0.1.0",
   "links": {


### PR DESCRIPTION
No need to define different upstream versions for testnet networks anymore, latest lighthouse [release](https://github.com/sigp/lighthouse/releases/tag/v7.0.0) works for all networks.


Upstream version already set in base `docker-compose.yml`